### PR TITLE
Small bugfixes for VR

### DIFF
--- a/HatchingShader.shader
+++ b/HatchingShader.shader
@@ -58,6 +58,13 @@ Shader "Custom/HatchingShader"
             float2x2 m = rotateFnc(b);
             return float4(mul(m, a.xz), a.yw).xzyw;
         }
+
+        #ifdef USING_STEREO_MATRICES
+        static float3 centerCameraPos = 0.5 * (unity_StereoWorldSpaceCameraPos[0] +  unity_StereoWorldSpaceCameraPos[1]);
+        #else
+        static float3 centerCameraPos = _WorldSpaceCameraPos;
+        #endif
+
         ENDCG
 
         Pass
@@ -115,7 +122,7 @@ Shader "Custom/HatchingShader"
             fixed4 frag(v2f i): SV_Target
             {
                 float3 N = i.normal;
-                float3 V = normalize(_WorldSpaceCameraPos.xyz - i.wpos.xyz);
+                float3 V = normalize(centerCameraPos.xyz - i.wpos.xyz);
 
                 float NdotV = max(0, dot(N, V));
                 float NNdotV = 1 - dot(N, V);
@@ -243,7 +250,7 @@ Shader "Custom/HatchingShader"
                 lightCol.rgb += max(0, ShadeSH9(float4(N, 1)));
 
                 float3 L = lightDir;
-                float3 V = normalize(_WorldSpaceCameraPos.xyz - i.wpos.xyz);
+                float3 V = normalize(centerCameraPos.xyz - i.wpos.xyz);
 
                 float NdotV = max(0, dot(N, V));
                 float NNdotV = 1 - dot(N, V);
@@ -419,7 +426,7 @@ Shader "Custom/HatchingShader"
                 float3 worldNormal = mul(TBN, tangentNormal);
 
                 float3 N = lerp(i.normal, worldNormal, saturate(length(tangentNormal) * 100));
-                float3 V = normalize(_WorldSpaceCameraPos.xyz - i.wpos.xyz);
+                float3 V = normalize(centerCameraPos.xyz - i.wpos.xyz);
 
                 float3 lightDir;
                 #if defined(POINT) || defined(POINT_COOKIE) || defined(SPOT)

--- a/HatchingShader.shader
+++ b/HatchingShader.shader
@@ -125,7 +125,7 @@ Shader "Custom/HatchingShader"
                 float3 V = normalize(centerCameraPos.xyz - i.wpos.xyz);
 
                 float NdotV = max(0, dot(N, V));
-                float NNdotV = 1 - dot(N, V);
+                float NNdotV = 1.01 - dot(N, V);
                 float rim = pow(NNdotV, _RimPower) * _RimAmplitude;
 
                 fixed4 col = _OutlineColor;
@@ -253,7 +253,7 @@ Shader "Custom/HatchingShader"
                 float3 V = normalize(centerCameraPos.xyz - i.wpos.xyz);
 
                 float NdotV = max(0, dot(N, V));
-                float NNdotV = 1 - dot(N, V);
+                float NNdotV = 1.01 - dot(N, V);
                 float rim = pow(NNdotV, _RimPower) * _RimAmplitude;
 
                 float NdotL = max(0, dot(L, N));
@@ -346,7 +346,7 @@ Shader "Custom/HatchingShader"
                 col.a = 1;
 
                 UNITY_APPLY_FOG(i.fogCoord, col);
-                return col;
+                return saturate(col);
             }
             ENDCG
             
@@ -439,7 +439,7 @@ Shader "Custom/HatchingShader"
                 float3 L = lightDir;
 
                 float NdotV = max(0, dot(N, V));
-                float NNdotV = 1 - dot(N, V);
+                float NNdotV = 1.01 - dot(N, V);
                 float rim = pow(NNdotV, _RimPower) * _RimAmplitude;
 
                 float NdotL = max(0, dot(L, N));
@@ -532,7 +532,7 @@ Shader "Custom/HatchingShader"
                 col.a = 1;
 
                 UNITY_APPLY_FOG(i.fogCoord, col);
-                return col;
+                return saturate(col);
             }
             ENDCG
             


### PR DESCRIPTION
"Improve support for single-pass stereo" -> this fixes shiny effect in VR caused by each eye seeing different hatching.

"Fix NaN when N dot V = 1" -> In the old version, this computation 1 - N dot V = 0 caused some NaN pixels. Using 1.01 instead of 1 results in little visual difference but avoids this instability. NaN pixels in HDR render target may result in extreme bloom (whole screen turns white).

After changes made 4 days ago, the second change might be unnecessary. I have not tested to see if it is necessary.

VRChatで使ったらこのシェーダーありがとうございます！Thanks for this awesome shader effect!!! I have used it in VRChat. <3 Lyuma